### PR TITLE
allows CORS for simone app list to work

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,5 +9,5 @@ location __PATH__ {
 
 	autoindex on;
 	autoindex_exact_size off;
-
+	add_header 'Access-Control-Allow-Origin' '*';
 }


### PR DESCRIPTION
Salut,

C'est pour permettre à https://yunohost.org/#/apps de marcher.

C'est déjà en prod.